### PR TITLE
YouTubeVideoRepositoryからDbVideoRepositoryへの移行

### DIFF
--- a/server/src/jaljalgotcha/di/container.py
+++ b/server/src/jaljalgotcha/di/container.py
@@ -2,6 +2,8 @@
 依存性注入コンテナの実装
 """
 from typing import Dict, Any, Optional, Type, TypeVar
+from src.jaljalgotcha.repositories.db_repository import DbVideoRepository
+from src.jaljalgotcha.db_integration import db_session
 
 T = TypeVar('T')
 
@@ -69,3 +71,6 @@ class Container:
 
 # グローバルインスタンス
 container = Container()
+
+# Register DbVideoRepository as the default VideoRepository
+container.register('video_repository', lambda c: DbVideoRepository(db_session))

--- a/server/src/jaljalgotcha/services/video_service.py
+++ b/server/src/jaljalgotcha/services/video_service.py
@@ -19,6 +19,38 @@ class VideoService:
             video_repository: 動画リポジトリのインスタンス
         """
         self.video_repository = video_repository
+
+    def _convert_filters(self, filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """
+        フィルターをYouTube API形式からDB形式に変換する
+
+        Args:
+            filters: 元のフィルター条件
+
+        Returns:
+            変換後のフィルター条件
+        """
+        if not filters:
+            return {}
+
+        converted_filters = {}
+
+        # YouTube APIのフィルターをDB用に変換
+        if 'max_results' in filters:
+            converted_filters['limit'] = filters['max_results']
+        if 'order' in filters:
+            converted_filters['order_by'] = filters['order']
+            converted_filters['order_dir'] = 'desc' if filters['order'] == 'date' else 'asc'
+
+        # DB固有のフィルターを追加
+        if 'max_duration' in filters:
+            converted_filters['max_duration'] = filters['max_duration']
+        if 'min_likes' in filters:
+            converted_filters['min_likes'] = filters['min_likes']
+        if 'min_views' in filters:
+            converted_filters['min_views'] = filters['min_views']
+
+        return converted_filters
     
     def get_video_combinations(self, target_duration: int, 
                               attempts: int = 3,
@@ -34,6 +66,9 @@ class VideoService:
         Returns:
             動画コレクションのリスト
         """
+        # フィルターを変換
+        filters = self._convert_filters(filters)
+
         # リポジトリから動画を取得
         videos = self.video_repository.get_videos(filters)
         

--- a/server/tests/test_db_repository.py
+++ b/server/tests/test_db_repository.py
@@ -1,0 +1,143 @@
+"""
+DbVideoRepositoryのテスト
+"""
+import pytest
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+# psycopg2のインポートをモックして、実際のDB接続を回避
+with patch.dict(sys.modules, {'psycopg2': MagicMock()}):
+    from src.jaljalgotcha.repositories.db_repository import DbVideoRepository
+    from src.jaljalgotcha.repositories.interfaces import VideoRepository
+    from src.jaljalgotcha.db.models_db import VideoModel
+
+
+@pytest.fixture
+def mock_db_session():
+    """モックDBセッションを提供するフィクスチャ"""
+    mock_session = MagicMock()
+    
+    # モッククエリの作成
+    mock_query = MagicMock()
+    mock_session.query.return_value = mock_query
+    
+    # フィルターメソッドがクエリを返すようにする
+    mock_query.filter.return_value = mock_query
+    mock_query.order_by.return_value = mock_query
+    
+    # サンプルデータを生成
+    mock_videos = [
+        VideoModel(
+            video_id="001",
+            channel_id="channel1",
+            title="サンプル動画1",
+            duration_seconds=120,
+            view_count=1000,
+            like_count=100,
+            comment_count=10,
+            thumbnail_url="https://example.com/thumb1.jpg",
+            published_at=datetime(2023, 1, 1),
+            updated_at=datetime.now()
+        ),
+        VideoModel(
+            video_id="002",
+            channel_id="channel1",
+            title="サンプル動画2",
+            duration_seconds=180,
+            view_count=2000,
+            like_count=200,
+            comment_count=20,
+            thumbnail_url="https://example.com/thumb2.jpg",
+            published_at=datetime(2023, 1, 2),
+            updated_at=datetime.now()
+        )
+    ]
+    
+    # allメソッドがサンプルデータを返すようにする
+    mock_query.all.return_value = mock_videos
+    
+    return mock_session
+
+
+@pytest.fixture
+def db_repository(mock_db_session):
+    """DbVideoRepositoryのインスタンスを提供するフィクスチャ"""
+    return DbVideoRepository(mock_db_session)
+
+
+def test_repository_interface(db_repository):
+    """VideoRepositoryインターフェースを実装していることを確認"""
+    assert isinstance(db_repository, VideoRepository)
+
+
+def test_get_videos_without_filters(db_repository, mock_db_session):
+    """フィルターなしで動画を取得するテスト"""
+    # リポジトリメソッドを呼び出す
+    videos = db_repository.get_videos()
+    
+    # 正しいクエリが実行されたことを確認
+    mock_db_session.query.assert_called_once()
+    mock_query = mock_db_session.query.return_value
+    mock_query.order_by.assert_called_once()
+    mock_query.all.assert_called_once()
+    
+    # 返された動画のリストを確認
+    assert len(videos) == 2
+    assert videos[0].id == "001"
+    assert videos[1].id == "002"
+
+
+def test_get_videos_with_filters(db_repository, mock_db_session):
+    """フィルター付きで動画を取得するテスト"""
+    # フィルターを指定
+    filters = {
+        'max_duration': 200,
+        'min_likes': 50,
+        'min_views': 500,
+        'order_by': 'likes',
+        'order_dir': 'desc'
+    }
+    
+    # リポジトリメソッドを呼び出す
+    videos = db_repository.get_videos(filters)
+    
+    # 正しいクエリが実行されたことを確認
+    mock_query = mock_db_session.query.return_value
+    assert mock_query.filter.call_count >= 3  # 3つのフィルター条件
+    mock_query.order_by.assert_called_once()  # 並び順が指定されている
+    
+    # 返された動画のリストを確認
+    assert len(videos) == 2
+
+
+def test_save_video(db_repository, mock_db_session):
+    """動画の保存テスト"""
+    # 新しい動画モデルを作成
+    new_video = VideoModel(
+        video_id="003",
+        channel_id="channel1",
+        title="新しい動画",
+        duration_seconds=240,
+        view_count=300,
+        like_count=30,
+        comment_count=3,
+        thumbnail_url="https://example.com/thumb3.jpg",
+        published_at=datetime(2023, 1, 3),
+        updated_at=datetime.now()
+    )
+    
+    # モックのqueryでfirstメソッドがNoneを返すように設定（新規追加のケース）
+    mock_query = mock_db_session.query.return_value
+    mock_query.filter.return_value.first.return_value = None
+    
+    # 保存を実行
+    result = db_repository.save_video(new_video)
+    
+    # addとcommitが呼ばれたことを確認
+    mock_db_session.add.assert_called_once_with(new_video)
+    mock_db_session.commit.assert_called_once()
+    mock_db_session.refresh.assert_called_once_with(new_video)
+    
+    # 結果を確認
+    assert result == new_video

--- a/server/tests/test_repository_integration.py
+++ b/server/tests/test_repository_integration.py
@@ -1,0 +1,138 @@
+"""
+DbVideoRepositoryとVideoServiceの統合テスト
+"""
+import pytest
+import sys
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+
+# psycopg2のインポートをモックして、実際のDB接続を回避
+with patch.dict(sys.modules, {'psycopg2': MagicMock()}):
+    from src.jaljalgotcha.repositories.db_repository import DbVideoRepository
+    from src.jaljalgotcha.services.video_service import VideoService
+    from src.jaljalgotcha.db.models_db import VideoModel
+    from src.jaljalgotcha.models import Video
+
+
+@pytest.fixture
+def mock_db_videos():
+    """モックデータベース動画のリストを提供するフィクスチャ"""
+    return [
+        VideoModel(
+            video_id="001",
+            channel_id="channel1",
+            title="サンプル動画1",
+            duration_seconds=120,  # 2分
+            view_count=1000,
+            like_count=100,
+            comment_count=10,
+            thumbnail_url="https://example.com/thumb1.jpg",
+            published_at=datetime(2023, 1, 1),
+            updated_at=datetime.now()
+        ),
+        VideoModel(
+            video_id="002",
+            channel_id="channel1",
+            title="サンプル動画2",
+            duration_seconds=180,  # 3分
+            view_count=2000,
+            like_count=200,
+            comment_count=20,
+            thumbnail_url="https://example.com/thumb2.jpg",
+            published_at=datetime(2023, 1, 2),
+            updated_at=datetime.now()
+        ),
+        VideoModel(
+            video_id="003",
+            channel_id="channel1",
+            title="サンプル動画3",
+            duration_seconds=240,  # 4分
+            view_count=3000,
+            like_count=300,
+            comment_count=30,
+            thumbnail_url="https://example.com/thumb3.jpg",
+            published_at=datetime(2023, 1, 3),
+            updated_at=datetime.now()
+        ),
+    ]
+
+
+@pytest.fixture
+def mock_db_session(mock_db_videos):
+    """モックDBセッションを提供するフィクスチャ"""
+    mock_session = MagicMock()
+    
+    # モッククエリの設定
+    mock_query = MagicMock()
+    mock_session.query.return_value = mock_query
+    
+    # フィルタメソッドの振る舞いを設定
+    mock_query.filter.return_value = mock_query
+    mock_query.order_by.return_value = mock_query
+    
+    # allメソッドがサンプルデータを返すように設定
+    mock_query.all.return_value = mock_db_videos
+    
+    return mock_session
+
+
+@pytest.fixture
+def db_repository(mock_db_session):
+    """DbVideoRepositoryのインスタンスを提供するフィクスチャ"""
+    return DbVideoRepository(mock_db_session)
+
+
+@pytest.fixture
+def video_service(db_repository):
+    """VideoServiceのインスタンスを提供するフィクスチャ"""
+    return VideoService(db_repository)
+
+
+def test_video_service_with_youtube_filters(video_service, mock_db_session):
+    """YouTube APIフィルター形式を使用した統合テスト"""
+    # YouTube API形式のフィルター
+    youtube_filters = {
+        'max_results': 10,
+        'order': 'date'
+    }
+    
+    # 動画の組み合わせを取得
+    combinations = video_service.get_video_combinations(
+        target_duration=600,
+        filters=youtube_filters
+    )
+    
+    # 結果を検証
+    assert len(combinations) > 0
+    
+    # DBクエリが正しく呼び出されたことを確認
+    mock_query = mock_db_session.query.return_value
+    mock_query.order_by.assert_called_once()
+    mock_query.all.assert_called_once()
+
+
+def test_video_service_with_db_filters(video_service, mock_db_session):
+    """DB固有のフィルター形式を使用した統合テスト"""
+    # DB固有のフィルター
+    db_filters = {
+        'max_duration': 300,
+        'min_likes': 100,
+        'min_views': 1000
+    }
+    
+    # 動画の組み合わせを取得
+    combinations = video_service.get_video_combinations(
+        target_duration=600,
+        filters=db_filters
+    )
+    
+    # 結果を検証
+    assert len(combinations) > 0
+    
+    # 各組み合わせが目標時間以内であることを確認
+    for combo in combinations:
+        assert combo.total_time <= 600
+        
+    # 結果がソートされていることを確認（残り時間が少ない順）
+    for i in range(1, len(combinations)):
+        assert combinations[i-1].remaining_time <= combinations[i].remaining_time

--- a/server/tests/test_video_service.py
+++ b/server/tests/test_video_service.py
@@ -1,0 +1,80 @@
+"""
+VideoServiceのテスト
+"""
+import pytest
+from unittest.mock import MagicMock
+from src.jaljalgotcha.services.video_service import VideoService
+from src.jaljalgotcha.repositories.interfaces import VideoRepository
+from src.jaljalgotcha.models import Video, VideoCollection
+
+
+@pytest.fixture
+def mock_video_repository():
+    """モックビデオリポジトリを提供するフィクスチャ"""
+    mock_repo = MagicMock(spec=VideoRepository)
+    
+    # 仮の動画データ
+    mock_videos = [
+        Video(id="001", title="サンプル動画1", duration=120),  # 2分
+        Video(id="002", title="サンプル動画2", duration=180),  # 3分
+        Video(id="003", title="サンプル動画3", duration=300),  # 5分
+    ]
+    
+    # get_videosメソッドがモックデータを返すように設定
+    mock_repo.get_videos.return_value = mock_videos
+    
+    return mock_repo
+
+
+@pytest.fixture
+def video_service(mock_video_repository):
+    """VideoServiceのインスタンスを提供するフィクスチャ"""
+    return VideoService(mock_video_repository)
+
+
+def test_filter_conversion(video_service, mock_video_repository):
+    """フィルター変換機能のテスト"""
+    # YouTube API形式のフィルター
+    youtube_filters = {
+        'max_results': 10,
+        'order': 'date'
+    }
+    
+    # サービスを呼び出す
+    video_service.get_video_combinations(target_duration=600, filters=youtube_filters)
+    
+    # モックのget_videosが変換されたフィルターで呼ばれたことを確認
+    mock_video_repository.get_videos.assert_called_once()
+    args = mock_video_repository.get_videos.call_args[0]
+    
+    # 引数が辞書であることを確認
+    assert isinstance(args[0], dict)
+    
+    # フィルターが正しく変換されていることを確認
+    converted_filters = args[0]
+    assert converted_filters['limit'] == 10
+    assert converted_filters['order_by'] == 'date'
+    assert converted_filters['order_dir'] == 'desc'
+
+
+def test_db_specific_filters(video_service, mock_video_repository):
+    """DB固有のフィルターが保持されることのテスト"""
+    # DB固有のフィルターを含むリクエスト
+    db_filters = {
+        'max_duration': 300,
+        'min_likes': 100,
+        'min_views': 1000
+    }
+    
+    # サービスを呼び出す
+    video_service.get_video_combinations(target_duration=600, filters=db_filters)
+    
+    # モックのget_videosが同じフィルターで呼ばれたことを確認
+    mock_video_repository.get_videos.assert_called_once()
+    args = mock_video_repository.get_videos.call_args[0]
+    
+    # フィルターが正しく渡されていることを確認
+    converted_filters = args[0]
+    assert converted_filters['max_duration'] == 300
+    assert converted_filters['min_likes'] == 100
+    assert converted_filters['min_views'] == 1000


### PR DESCRIPTION
## 概要

YouTube APIを使用するからデータベースを使用するへの移行を実装しました。

## 主な変更点

1. **依存性注入の変更**
   - DI コンテナでをデフォルトの実装として設定
   - の更新により、データベースからの動画取得に移行

2. **フィルター変換機能の追加**
   - にフィルター変換ロジックを実装
   - YouTube API形式のフィルター（, など）をDB形式（, , など）に変換

3. **テストの追加と実行**
   - の単体テスト
   - フィルター変換ロジックのテスト
   - 統合テストの追加
   - すべてのテストが正常に通過（12個のテストケース）

## 期待される効果

1. **パフォーマンスの向上**
   - データベースアクセスによる高速なレスポンス
   - YouTube APIの使用量削減

2. **柔軟なフィルタリング**
   - 視聴回数、いいね数など、より多様なフィルター条件に対応
   - データベース最適化による効率的なクエリ実行

## テスト結果

すべてのテストケースが成功しています：
- : 4件
- : 2件
- : 4件
- : 2件

## 今後の課題

1. SQLAlchemy 2.0への対応（現在は非推奨機能の警告あり）
2. データ同期の自動化設定（の定期実行）
3. データベースのパフォーマンス最適化

## レビュー時の確認ポイント

1. フィルター変換ロジックの妥当性
2. テストカバレッジの十分性
3. エラーハンドリングの適切性